### PR TITLE
fix: Add missing -c flag

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -99,7 +99,7 @@ export class Compiler {
 		}
 
 		await utility.mkdirs(path.dirname(outputPath));
-		const { stderr } = await utility.execute(compiler, [...flags, '-o', outputPath, srcPath]).catch(err => {
+		const { stderr } = await utility.execute(compiler, [...flags, '-c', '-o', outputPath, srcPath]).catch(err => {
 			if (err.err.code === 'ENOENT') {
 				throw new Error(`Not found '${compiler}. Have you install it?'`);
 			}


### PR DESCRIPTION
Fixes #6

## Problem

It seems `emcc` now doesn't generate bitcode. See #6 .

## Proposal

Add `-c` flag to compile command.
