### PR TITLE
fix: Use default import for mkdirp

### DIFF
--- a/src/utility.ts
+++ b/src/utility.ts
@@ -1,7 +1,7 @@
 import * as childProcess from 'child_process';
 import * as crypto from 'crypto';
 import * as fs from 'fs';
-import * as mkdirp from 'mkdirp';
+import mkdirp from 'mkdirp';
 import * as path from 'path';
 import { promisify } from 'util';
 import { loader } from 'webpack';
@@ -10,7 +10,7 @@ const stat = promisify(fs.stat);
 const isWindows = /^win/.test(process.platform);
 
 export const exists = fs.existsSync;
-export const mkdirs = promisify(mkdirp);
+export const mkdirs = mkdirp;
 export const readFile = promisify(fs.readFile);
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
 		"removeComments": true,
 		"preserveConstEnums": true,
 		"sourceMap": true,
-		"moduleResolution": "node"
+		"moduleResolution": "node",
+		"allowSyntheticDefaultImports": true
 	},
 	"include": [
 		"src/**/*"


### PR DESCRIPTION
Fixes #10 

## Proposal

Use default import for `mkdirp` to fix TypeError.

## Side effect

`tsconfig.json`: `allowSyntheticDefaultImports` is now `true`.