### PR TITLE
feat: Accept commands and paths for options

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ emcc-loader is configuable on webpack.config.js.
 - buildDir : string
 -- [Required] absolute path to temporary directory used by emcc.
 - cc : string
--- [default=emcc] c compiler path.
+-- [default=emcc] c compiler path or command.
 - cxx : string
--- [default=em++] c++ compiler path.
+-- [default=em++] c++ compiler path or command.
 - ld : string
--- [default=emcc] linker path.
+-- [default=emcc] linker path or command.
 - commonFlags : string[]
 -- [default=[]] array of flags passed to all emcc/em++ commands.
 - cFlags : string[]

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -128,7 +128,9 @@ export class Compiler {
 
 		await utility.mkdirs(path.dirname(outputPath), undefined);
 		const { stderr } = await utility
-			.execute(compiler, [...flags, '-c', '-o', outputPath, srcPath])
+			.execute(compiler, [...flags, '-c', '-o', outputPath, srcPath], {
+				shell: true,
+			})
 			.catch(err => {
 				if (err.err.code === 'ENOENT') {
 					throw new Error(
@@ -166,7 +168,7 @@ export class Compiler {
 		}
 		await utility.mkdirs(path.dirname(outputPath), undefined);
 		const { stderr } = await utility
-			.execute(options.ld, flags)
+			.execute(options.ld, flags, { shell: true })
 			.catch(err => {
 				if (err.err.code === 'ENOENT') {
 					throw new Error(

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -21,11 +21,9 @@ export async function getDependencies(
 	absPath: string,
 	flags: string[]
 ) {
-	const { stdout } = await execute(compiler, [
-		...flags,
-		'-MM',
-		absPath,
-	]).catch(err => {
+	const { stdout } = await execute(compiler, [...flags, '-MM', absPath], {
+		shell: true,
+	}).catch(err => {
 		throw err.err;
 	});
 	const dependencies = stdout


### PR DESCRIPTION
Resolves #9 

**👨‍🏭 WIP:**  Awaiting close of #10 . As soon as it is fixed I'll test and submit it formally.

---

## Proposal

* Use option `{ shell: true }` for `utility.execute()`([`child_process.execFile()`](https://nodejs.org/api/child_process.html#child_process_child_process_execfile_file_args_options_callback)) to accept commands with args for `cc`, `cxx` and `ld`. (See #9 )
* Update README to follow above.

## Known issues

* Because of `message.parseClangMessage()`, the output messages may be not correct by commands that used: some messages that not match format of `emdsk` may be ignored and not shown on console. I believe it is not problem while we use `emcc`/`em++` as original options.
