### PR TITLE
feat: Add cwd option to use relative paths for compiler args

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ emcc-loader is configuable on webpack.config.js.
 
 - buildDir : string
 -- [Required] absolute path to temporary directory used by emcc.
+- cwd : string
+-- [default=undefined] working directory for compilers. If specified, all paths passed to compilers will be relative against cwd.
 - cc : string
 -- [default=emcc] c compiler path.
 - cxx : string

--- a/src/option.ts
+++ b/src/option.ts
@@ -12,6 +12,11 @@ export type LoaderOption = {
 	buildDir: string;
 
 	/**
+	 * A path to working directory for compiler.
+	 */
+	cwd?: string;
+
+	/**
 	 * Option for --pre-js
 	 */
 	preJs?: string;
@@ -74,6 +79,7 @@ export function parseOption(context: loader.LoaderContext): LoaderOption {
 		cc: <string>options.cc || 'emcc',
 		cxx: <string>options.cxx || 'em++',
 		ld: <string>options.ld || 'emcc',
+		cwd: <string | undefined>options.cwd,
 		/* eslint-disable @typescript-eslint/no-explicit-any */
 		commonFlags: <string[]>(<any>options.commonFlags) || [],
 		cFlags: <string[]>(<any>options.cFlags) || [],

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -19,13 +19,14 @@ export const readFile = promisify(fs.readFile);
 export async function getDependencies(
 	compiler: string,
 	absPath: string,
-	flags: string[]
+	flags: string[],
+	cwd?: string
 ) {
-	const { stdout } = await execute(compiler, [
-		...flags,
-		'-MM',
-		absPath,
-	]).catch(err => {
+	const { stdout } = await execute(
+		compiler,
+		[...flags, '-MM', cwd ? path.relative(cwd, absPath) : absPath],
+		{ cwd }
+	).catch(err => {
 		throw err.err;
 	});
 	const dependencies = stdout


### PR DESCRIPTION
Resolves #13 

## Proposal

* Add `cwd` as loader option. If specified, change paths that are passed to compilers to relative ones.
* Update `README` to follow the above change.