### PR TITLE
Handle errors from execute() by its returning values

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -127,16 +127,16 @@ export class Compiler {
 		}
 
 		await utility.mkdirs(path.dirname(outputPath), undefined);
-		const { stderr } = await utility
-			.execute(compiler, [...flags, '-c', '-o', outputPath, srcPath])
-			.catch(err => {
-				if (err.err.code === 'ENOENT') {
-					throw new Error(
-						`Not found '${compiler}. Have you install it?'`
-					);
-				}
-				return { stderr: err.stderr as string | Buffer };
-			});
+		const { stderr, err } = await utility.execute(compiler, [
+			...flags,
+			'-c',
+			'-o',
+			outputPath,
+			srcPath,
+		]);
+
+		if (err) throw err;
+
 		return message.parseClangMessage(stderr.toString());
 	}
 
@@ -165,16 +165,10 @@ export class Compiler {
 			flags.unshift('--post-js', options.postJs);
 		}
 		await utility.mkdirs(path.dirname(outputPath), undefined);
-		const { stderr } = await utility
-			.execute(options.ld, flags)
-			.catch(err => {
-				if (err.err.code === 'ENOENT') {
-					throw new Error(
-						`Not found '${options.ld}. Have you install it?'`
-					);
-				}
-				return { stderr: err.stderr as string | Buffer };
-			});
+		const { stderr, err } = await utility.execute(options.ld, flags);
+
+		if (err) throw err;
+
 		return message.parseClangMessage(stderr.toString());
 	}
 

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -21,13 +21,10 @@ export async function getDependencies(
 	absPath: string,
 	flags: string[]
 ) {
-	const { stdout } = await execute(compiler, [
-		...flags,
-		'-MM',
-		absPath,
-	]).catch(err => {
-		throw err.err;
-	});
+	const { stdout, err } = await execute(compiler, [...flags, '-MM', absPath]);
+
+	if (err) throw err;
+
 	const dependencies = stdout
 		.toString()
 		.trim()


### PR DESCRIPTION
Fixes #16 

This PR fixes error handling of `utility.execute()`. It does not throw any errors, but returns them as returning values.

Note: I removed some detections with `err.err.code === 'ENOENT'` because it cause TypeError: `Property 'code' does not exist on type 'Error'.ts(2339)`. At base code `err` is typed as `any` so it was not a problem.  I'm not sure how to fix it. 🤔